### PR TITLE
retry requests and handle multiple candidates in one request

### DIFF
--- a/chat.py
+++ b/chat.py
@@ -1,18 +1,21 @@
 from abc import ABC, abstractmethod
+from typing import List
 
 
 class Chat(ABC):
-    def __init__(self, model: str):
+    @abstractmethod
+    def __init__(self, model: str, system_prompt: str):
         self.client = None
         self.model = model
         pass
 
     @abstractmethod
-    def prompt(self, system_prompt: str, message: str) -> str:
+    def prompt(self, message: str, completions: int = 1) -> List[str]:
         """
-        This method should take a message as input and return a response.
+        This method should take a message as input and return a responses.
 
         :param message: The message to prompt the virtual assistant with.
+        :param completions: Number of completions to generate.
         :return: The response from the virtual assistant.
         """
         pass

--- a/chatgpt.py
+++ b/chatgpt.py
@@ -1,24 +1,41 @@
 from chat import Chat
 from dotenv import load_dotenv
 import openai
+from google.api_core import retry
+from typing import List
+import time
 import os
 
 
 class ChatGPT(Chat):
-    def __init__(self, model: str = "gpt-3.5-turbo"):
+    def __init__(self, model: str = "gpt-3.5-turbo", system_prompt: str = ""):
         load_dotenv()
         OPENAI_KEY = os.getenv("OPENAI_KEY")
         self.client = openai.OpenAI(api_key=OPENAI_KEY)
         self.model = model
+        self.system_prompt = system_prompt
         pass
 
-    def prompt(self, system_prompt: str, message: str, temperature: float = 0.2) -> str:
+    @retry.Retry(
+        predicate=lambda exception: exception is openai.RateLimitError,
+        initial=1.0,
+        maximum=64.0,
+        multiplier=2.0,
+        timeout=60,
+    )
+    def prompt(
+        self,
+        message: str,
+        completions: int = 1,
+        temperature: float = 0.2,
+    ) -> List[str]:
         response = self.client.chat.completions.create(
             model=self.model,
             messages=[
-                {"role": "system", "content": system_prompt},
+                {"role": "system", "content": self.system_prompt},
                 {"role": "user", "content": message},
             ],
             temperature=temperature,
+            n=completions,
         )
-        return response.choices[0].message.content
+        return [choice.message.content for choice in response.choices]

--- a/gemini.py
+++ b/gemini.py
@@ -1,20 +1,41 @@
 from chat import Chat
 from dotenv import load_dotenv
 import google.generativeai as genai
+from google.api_core import retry
+from typing import List
 import os
 
 
 class Gemini(Chat):
-    def __init__(self, model: str = "gemini-1.5-pro"):
+    def __init__(self, model: str = "gemini-1.5-pro", system_prompt: str = ""):
         load_dotenv()
         GOOGLE_KEY = os.getenv("GOOGLE_KEY")
         genai.configure(api_key=GOOGLE_KEY)
-        self.client = genai.GenerativeModel(model)
+        self.client = genai.GenerativeModel(model, system_instruction=[system_prompt])
+        self.model = model
         pass
 
-    def prompt(self, system_prompt: str, message: str) -> str:
-        chat = self.client.start_chat(
-            history=[{"role": "user", "parts": [system_prompt]}]
-        )
-        response = chat.send_message(message)
-        return response.text
+    @retry.Retry(
+        predicate=retry.if_transient_error,
+        initial=1.0,
+        maximum=64.0,
+        multiplier=2.0,
+        timeout=60,
+    )
+    def prompt(
+        self,
+        message: str,
+        completions: int = 1,
+        temperature: float = 0.2,
+    ) -> List[str]:
+        # Although the gemini api provides an option candidate_count the only currently available value is 1
+        candidates = []
+        for i in range(completions):
+            response = self.client.generate_content(
+                message,
+                generation_config=genai.GenerationConfig(
+                    temperature=temperature, candidate_count=1
+                ),
+            )
+            candidates.append(response.text)
+        return candidates


### PR DESCRIPTION
Retry request if it hits rate limit (or any other transient error)

Request multiple candidates in one request instead of many request for one candidate (currently only supported by chatgpt, but gemini should support in the future) 